### PR TITLE
Fix #5: base.xml change from ActorManager2 to ActionManager5E

### DIFF
--- a/scripts/automatic_range_modifier/manager_action_attack.lua
+++ b/scripts/automatic_range_modifier/manager_action_attack.lua
@@ -369,7 +369,7 @@ function modAttack(rSource, rTarget, rRoll)
 		end	
 
 		-- Get ability modifiers
-		local nBonusStat, nBonusEffects = ActorManager2.getAbilityEffectsBonus(rSource, sActionStat);
+		local nBonusStat, nBonusEffects = ActorManager5E.getAbilityEffectsBonus(rSource, sActionStat);
 		if nBonusEffects > 0 then
 			bEffects = true;
 			nAddMod = nAddMod + nBonusStat;
@@ -427,7 +427,7 @@ function modAttack(rSource, rTarget, rRoll)
 		nAddMod = nAddMod - 2;
 	end
 	
-	local bDefADV, bDefDIS = ActorManager2.getDefenseAdvantage(rSource, rTarget, aAttackFilter);
+	local bDefADV, bDefDIS = ActorManager5E.getDefenseAdvantage(rSource, rTarget, aAttackFilter);
 	if bDefADV then
 		bADV = true;
 	end
@@ -463,7 +463,7 @@ function onAttack(rSource, rTarget, rRoll)
 	rAction.nTotal = ActionsManager.total(rRoll);
 	rAction.aMessages = {};
 	
-	local nDefenseVal, nAtkEffectsBonus, nDefEffectsBonus = ActorManager2.getDefenseValue(rSource, rTarget, rRoll);
+	local nDefenseVal, nAtkEffectsBonus, nDefEffectsBonus = ActorManager5E.getDefenseValue(rSource, rTarget, rRoll);
 	if nAtkEffectsBonus ~= 0 then
 		rAction.nTotal = rAction.nTotal + nAtkEffectsBonus;
 		local sFormat = "[" .. Interface.getString("effects_tag") .. " %+d]"

--- a/scripts/manager_action_save.lua
+++ b/scripts/manager_action_save.lua
@@ -123,7 +123,7 @@ function getRoll(rActor, sSave)
 	local rRoll = {};
 	rRoll.sType = "save";
 	rRoll.aDice = { "d20" };
-	local nMod, bADV, bDIS, sAddText = ActorManager2.getSave(rActor, sSave);
+	local nMod, bADV, bDIS, sAddText = ActorManager5E.getSave(rActor, sSave);
 	rRoll.nMod = nMod;
 	
 	rRoll.sDesc = "[SAVE] " .. StringManager.capitalize(sSave);
@@ -302,7 +302,7 @@ function modSave(rSource, rTarget, rRoll)
 			sSaveAbility = sSave;
 		end
 		if sSaveAbility then
-			local nBonusStat, nBonusEffects = ActorManager2.getAbilityEffectsBonus(rSource, sSaveAbility);
+			local nBonusStat, nBonusEffects = ActorManager5E.getAbilityEffectsBonus(rSource, sSaveAbility);
 			if nBonusEffects > 0 then
 				bEffects = true;
 				nAddMod = nAddMod + nBonusStat;
@@ -479,7 +479,7 @@ function performSystemShockRoll(draginfo, rActor)
 	local rRoll = { };
 	rRoll.sType = "systemshock";
 	rRoll.aDice = { "d20" };
-	local nMod, bADV, bDIS, sAddText = ActorManager2.getSave(rActor, "constitution");
+	local nMod, bADV, bDIS, sAddText = ActorManager5E.getSave(rActor, "constitution");
 	rRoll.nMod = nMod;
 	
 	rRoll.sDesc = "[SYSTEM SHOCK]";
@@ -657,11 +657,11 @@ function onDeathRoll(rSource, rTarget, rRoll)
 
 	local rMessage = ActionsManager.createActionMessage(rSource, rRoll);
 
-	if ActorManager2.getPercentWounded(rSource) >= 1 then
+	if ActorManager5E.getPercentWounded(rSource) >= 1 then
 		local nTotal = ActionsManager.total(rRoll);
 		
 		local bStatusCheck = true;
-		local _,sOriginalStatus = ActorManager2.getPercentWounded(rSource);
+		local _,sOriginalStatus = ActorManager5E.getPercentWounded(rSource);
 		
 		local nFirstDie = 0;
 		if #(rRoll.aDice) > 0 then
@@ -733,7 +733,7 @@ function onDeathRoll(rSource, rTarget, rRoll)
 				bShowStatus = not OptionsManager.isOption("SHNPC", "off");
 			end
 			if bShowStatus then
-				local _,sNewStatus = ActorManager2.getPercentWounded(rSource);
+				local _,sNewStatus = ActorManager5E.getPercentWounded(rSource);
 				if sOriginalStatus ~= sNewStatus then
 					rMessage.text = rMessage.text .. " [" .. Interface.getString("combat_tag_status") .. ": " .. sNewStatus .. "]";
 				end
@@ -816,7 +816,7 @@ function performConcentrationRoll(draginfo, rActor, nTargetDC)
 	local rRoll = { };
 	rRoll.sType = "concentration";
 	rRoll.aDice = { "d20" };
-	local nMod, bADV, bDIS, sAddText = ActorManager2.getSave(rActor, "constitution");
+	local nMod, bADV, bDIS, sAddText = ActorManager5E.getSave(rActor, "constitution");
 	rRoll.nMod = nMod;
 	
 	rRoll.sDesc = "[CONCENTRATION]";


### PR DESCRIPTION
What the title says! Simple fix for the new ActorManager binding name. 

Screenshot showing the module loaded successfully and making an attack vs. an unsuspecting Aboleth: 
![image](https://user-images.githubusercontent.com/1887955/112517515-c7075e80-8d6e-11eb-8eca-46854c82000d.png)
